### PR TITLE
Polopoly-cli integration [NOTE WILL NOT COMPILE UNTIL NEXT SNAPSHOT]

### DIFF
--- a/src/main/java/com/polopoly/ps/pcmd/PcmdPolopolyCLICommand.java
+++ b/src/main/java/com/polopoly/ps/pcmd/PcmdPolopolyCLICommand.java
@@ -1,0 +1,51 @@
+package com.polopoly.ps.pcmd;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.MissingArgumentException;
+import org.apache.commons.cli.Options;
+
+import com.polopoly.cli.command.PolopolyCLICommand;
+import com.polopoly.ps.pcmd.argument.ArgumentException;
+import com.polopoly.ps.pcmd.argument.CommandLineArgumentParser;
+import com.polopoly.ps.pcmd.argument.DefaultArguments;
+
+public class PcmdPolopolyCLICommand implements PolopolyCLICommand
+{
+    private DefaultArguments args;
+
+    @Override
+    public void execute()
+    {
+        new Main().execute(args);
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "A PCMD bridge for polopoly-cli";
+    }
+
+    @Override
+    public Options buildOptions()
+    {
+        return new Options();
+    }
+
+    @Override
+    public String getShortUsage()
+    {
+        return "[OPTIONS]";
+    }
+
+    @Override
+    public void parseCommandLine(CommandLine arg0) throws MissingArgumentException
+    {
+        try
+        {
+            args = new CommandLineArgumentParser().parse(arg0.getArgs());
+        } catch (ArgumentException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/polopoly/ps/pcmd/PcmdPolopolyCLICommandProvider.java
+++ b/src/main/java/com/polopoly/ps/pcmd/PcmdPolopolyCLICommandProvider.java
@@ -1,0 +1,15 @@
+package com.polopoly.ps.pcmd;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.polopoly.cli.command.PolopolyCLICommand;
+import com.polopoly.cli.command.PolopolyCLICommandProvider;
+
+public class PcmdPolopolyCLICommandProvider implements PolopolyCLICommandProvider
+{
+    public Map<String, PolopolyCLICommand> getPolopolyCLICommands()
+    {
+        return Collections.<String, PolopolyCLICommand>singletonMap("pcmd", new PcmdPolopolyCLICommand());
+    }
+}

--- a/src/resources/jar-metainf/services/com.polopoly.cli.command.PolopolyCLICommandProvider
+++ b/src/resources/jar-metainf/services/com.polopoly.cli.command.PolopolyCLICommandProvider
@@ -1,0 +1,1 @@
+com.polopoly.ps.pcmd.PcmdPolopolyCLICommandProvider


### PR DESCRIPTION
Added the PolopolyCLICommandProvider that allows integration of PCMD with nitro style projects
    and the artifacts created from the p:assemble-dist command.
    Using the extension flag (-Dp.extend) any PCMD tools found on the classpath can be invoked
    using the prefix java -jar polopoly-cli.jar pcmd [normal pcmd tools arguments]
