### PR TITLE
Fixed httpclient version in order to interact with solr.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!-- needed for solr -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.3</version>
+		</dependency>
 		<dependency>
 			<groupId>com.polopoly</groupId>
 			<artifactId>polopoly</artifactId>


### PR DESCRIPTION
When using pcmd solr command a classnotfound error was thrown due to httpclient version mismatch
